### PR TITLE
fix: replace z.iso.datetime with z.string().datetime for Zod v3 compatibility

### DIFF
--- a/src/lib/checkpoint-schema.js
+++ b/src/lib/checkpoint-schema.js
@@ -91,7 +91,7 @@ exports.CheckpointManifestSchema = zod_1.z
         .string()
         .regex(/^S[0-9]{2}_[a-z]+_[a-z_]+$/, "Stage ID must follow format S{NN}_{verb}_{noun}"),
     // Timing Fields
-    createdAt: zod_1.z.iso.datetime({ message: "Invalid ISO 8601 datetime format" }),
+    createdAt: zod_1.z.string().datetime({ message: "Invalid ISO 8601 datetime format" }),
     executionCount: zod_1.z.number().int().nonnegative("Execution count must be non-negative"),
     // Status Fields
     status: exports.CheckpointStatusSchema,

--- a/src/lib/checkpoint-schema.ts
+++ b/src/lib/checkpoint-schema.ts
@@ -343,7 +343,7 @@ export const CheckpointManifestSchema = z
       ),
 
     // Timing Fields
-    createdAt: z.iso.datetime({ message: "Invalid ISO 8601 datetime format" }),
+    createdAt: z.string().datetime({ message: "Invalid ISO 8601 datetime format" }),
     executionCount: z.number().int().nonnegative("Execution count must be non-negative"),
 
     // Status Fields


### PR DESCRIPTION
## Summary
- Fixes #9: MCP server fails with 'z.iso.datetime is not a function'
- Replaced `z.iso.datetime()` (Zod v4 API) with `z.string().datetime()` (Zod v3 API)
- Updated both `src/lib/checkpoint-schema.ts` and `src/lib/checkpoint-schema.js`

## Test plan
- [x] Schema loads successfully without errors
- [ ] Verify MCP server starts without datetime validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)