### PR TITLE
chore(mcp): refresh package-lock

### DIFF
--- a/src/mcp/package-lock.json
+++ b/src/mcp/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@gyoshu/mcp-server",
-  "version": "0.4.33",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gyoshu/mcp-server",
-      "version": "0.4.33",
+      "version": "0.5.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "sanitize-html": "^2.17.0",
         "zod": "^3.23.0"
       },
       "bin": {
-        "gyoshu-mcp": "build/index.js"
+        "gyoshu-mcp": "build/index.cjs"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -969,7 +969,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1842,7 +1841,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary
- apply the pending src/mcp/package-lock.json update as a standalone change
- keep lockfile refresh isolated from skill-ops and CI/hook infrastructure changes

## Notes
- no source logic changes
- lockfile-only maintenance PR
